### PR TITLE
Fix global-thread lag in Folia

### DIFF
--- a/src/main/java/de/rayzs/pat/api/communication/impl/BukkitClient.java
+++ b/src/main/java/de/rayzs/pat/api/communication/impl/BukkitClient.java
@@ -8,6 +8,7 @@ import de.rayzs.pat.plugin.BukkitLoader;
 import de.rayzs.pat.api.communication.*;
 import org.bukkit.entity.Player;
 import org.bukkit.*;
+import java.util.Iterator;
 
 public class BukkitClient implements Client, PluginMessageListener {
 
@@ -56,12 +57,22 @@ public class BukkitClient implements Client, PluginMessageListener {
             return;
         }
 
-
-        try {
-            SERVER.sendPluginMessage(BukkitLoader.getPlugin(), CHANNEL_NAME, preparedPacket);
-        } catch (Exception exception) {
-            exception.printStackTrace();
+        final Player carrier = selectCarrier();
+        if (carrier == null) {
+            return;
         }
+
+        PATScheduler.execute(() -> {
+            if (!carrier.isOnline()) {
+                return;
+            }
+
+            try {
+                carrier.sendPluginMessage(BukkitLoader.getPlugin(), CHANNEL_NAME, preparedPacket);
+            } catch (Exception exception) {
+                exception.printStackTrace();
+            }
+        }, carrier);
     }
 
     @Override
@@ -83,5 +94,10 @@ public class BukkitClient implements Client, PluginMessageListener {
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+    }
+
+    private Player selectCarrier() {
+        final Iterator<? extends Player> iterator = SERVER.getOnlinePlayers().iterator();
+        return iterator.hasNext() ? iterator.next() : null;
     }
 }


### PR DESCRIPTION
We have noticed severe lag spikes in the global thread when using this plugin in in a Folia server with 100+ players. Here is a snippet of Spark showing this: 
<img width="1887" height="748" alt="image" src="https://github.com/user-attachments/assets/26212168-4979-4ce7-acca-6228e2db6981" />

To fix this, we replace the backend plugin-message dispatch in BukkitClient from Server.sendPluginMessage to single carrier-player dispatch via PATScheduler.execute(..., player). 
This keeps plugin messaging on a player/entity scheduler for Folia, reducing redundant per-player sends and feedback amplification that were loading the global scheduler thread under high player counts