### PR TITLE
fix: replace printStackTrace with logger calls + minor code quality

### DIFF
--- a/src/main/java/de/rayzs/pat/plugin/command/commands/local/system/PostDebugCommand.java
+++ b/src/main/java/de/rayzs/pat/plugin/command/commands/local/system/PostDebugCommand.java
@@ -22,7 +22,7 @@ public class PostDebugCommand extends ProCommand {
             sender.sendMessage(Storage.ConfigSections.Messages.POST_DEBUG.SUCCESS.replace("%link%", Objects.requireNonNull(Logger.post())));
         } catch (Exception exception) {
             sender.sendMessage(Storage.ConfigSections.Messages.POST_DEBUG.FAILED);
-            exception.printStackTrace();
+            Logger.warning("Failed to post debug information: " + exception.getMessage());
         }
 
         return true;

--- a/src/main/java/de/rayzs/pat/plugin/listeners/velocity/VelocityAntiTabListener.java
+++ b/src/main/java/de/rayzs/pat/plugin/listeners/velocity/VelocityAntiTabListener.java
@@ -128,7 +128,6 @@ public class VelocityAntiTabListener {
             });
         } catch (Exception exception) {
             Logger.warning("An error occurred while processing commands in PAT: " + exception.getMessage());
-            exception.printStackTrace();
         }
     }
 }

--- a/src/main/java/de/rayzs/pat/plugin/packetanalyzer/bukkit/BukkitPacketAnalyzer.java
+++ b/src/main/java/de/rayzs/pat/plugin/packetanalyzer/bukkit/BukkitPacketAnalyzer.java
@@ -89,7 +89,7 @@ public class BukkitPacketAnalyzer {
 
         } catch (Exception exception) {
             if (!Storage.ConfigSections.Settings.INJECTION_FAILED.SUPPRESS_EXCEPTIONS) {
-                exception.printStackTrace();
+                Logger.warning("Failed to inject player: " + exception.getMessage());
             }
 
             return false;
@@ -166,7 +166,7 @@ public class BukkitPacketAnalyzer {
 
 
                 super.channelRead(channel, packetObj);
-            } catch (Throwable exception) { exception.printStackTrace(); }
+            } catch (Throwable exception) { Logger.warning("Error during channel read: " + exception.getMessage()); }
         }
 
         @Override
@@ -211,7 +211,7 @@ public class BukkitPacketAnalyzer {
                 super.write(channel, packetObj, promise);
 
             } catch (Throwable exception) {
-                exception.printStackTrace();
+                Logger.warning("Error during packet write: " + exception.getMessage());
             }
         }
     }

--- a/src/main/java/de/rayzs/pat/plugin/packetanalyzer/bukkit/handlers/ModernPacketHandler.java
+++ b/src/main/java/de/rayzs/pat/plugin/packetanalyzer/bukkit/handlers/ModernPacketHandler.java
@@ -152,7 +152,7 @@ public class ModernPacketHandler implements BukkitPacketHandler {
                 return false;
 
             } catch (Throwable throwable) {
-                throwable.printStackTrace();
+                Logger.warning("Error handling 1.21 packet: " + throwable.getMessage());
             }
 
             return !cancelsBeforeHand;
@@ -255,7 +255,7 @@ public class ModernPacketHandler implements BukkitPacketHandler {
             BukkitPacketAnalyzer.sendPacket(player.getUniqueId(), packet);
 
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Error in unmodifiable tab completion: " + exception.getMessage());
         }
 
         return false;
@@ -271,7 +271,7 @@ public class ModernPacketHandler implements BukkitPacketHandler {
             field.setAccessible(false);
             return result;
         } catch (Throwable throwable) {
-            throwable.printStackTrace();
+            Logger.warning("Error getting suggestion from entry: " + throwable.getMessage());
         }
 
         return "";

--- a/src/main/java/de/rayzs/pat/plugin/packetanalyzer/proxy/BungeePacketAnalyzer.java
+++ b/src/main/java/de/rayzs/pat/plugin/packetanalyzer/proxy/BungeePacketAnalyzer.java
@@ -103,7 +103,7 @@ public class BungeePacketAnalyzer {
 
         } catch (Exception exception) {
             if (!Storage.ConfigSections.Settings.INJECTION_FAILED.SUPPRESS_EXCEPTIONS) {
-                exception.printStackTrace();
+                Logger.warning("Injection failed: " + exception.getMessage());
             }
 
             return false;

--- a/src/main/java/de/rayzs/pat/plugin/packetanalyzer/proxy/VelocityPacketAnalyzer.java
+++ b/src/main/java/de/rayzs/pat/plugin/packetanalyzer/proxy/VelocityPacketAnalyzer.java
@@ -59,7 +59,7 @@ public class VelocityPacketAnalyzer {
             }
 
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Failed to initialize suggestion provider: " + exception.getMessage());
         }
     }
 
@@ -125,7 +125,7 @@ public class VelocityPacketAnalyzer {
 
         } catch (Exception exception) {
             if (!Storage.ConfigSections.Settings.INJECTION_FAILED.SUPPRESS_EXCEPTIONS) {
-                exception.printStackTrace();
+                Logger.warning("Velocity injection failed: " + exception.getMessage());
             }
 
             return false;
@@ -249,7 +249,7 @@ public class VelocityPacketAnalyzer {
                         return;
 
                 } catch (Exception exception) {
-                    exception.printStackTrace();
+                    Logger.warning("Error handling signed chat command: " + exception.getMessage());
                 }
             }
 

--- a/src/main/java/de/rayzs/pat/plugin/system/communication/pmc/impl/BukkitPluginMessageClient.java
+++ b/src/main/java/de/rayzs/pat/plugin/system/communication/pmc/impl/BukkitPluginMessageClient.java
@@ -7,6 +7,7 @@ import de.rayzs.pat.utils.scheduler.PATScheduler;
 import org.bukkit.plugin.messaging.PluginMessageListener;
 import de.rayzs.pat.utils.CommunicationPackets;
 import de.rayzs.pat.plugin.BukkitLoader;
+import de.rayzs.pat.plugin.logger.Logger;
 import org.bukkit.entity.Player;
 import org.bukkit.*;
 
@@ -75,7 +76,7 @@ public class BukkitPluginMessageClient implements PluginMessageClient, PluginMes
             try {
                 carrier.sendPluginMessage(BukkitLoader.getPlugin(), CHANNEL_NAME, preparedPacket);
             } catch (Exception exception) {
-                exception.printStackTrace();
+                Logger.warning("Failed to send plugin message: " + exception.getMessage());
             }
         }, carrier);
     }
@@ -97,7 +98,7 @@ public class BukkitPluginMessageClient implements PluginMessageClient, PluginMes
             PATScheduler.createScheduler(() -> Communicator.get().handleP2BPacket((CommunicationPackets.PATPacket) packetObj));
 
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Error reading plugin message: " + exception.getMessage());
         }
     }
 

--- a/src/main/java/de/rayzs/pat/plugin/system/communication/pmc/impl/BungeePluginMessageClient.java
+++ b/src/main/java/de/rayzs/pat/plugin/system/communication/pmc/impl/BungeePluginMessageClient.java
@@ -5,6 +5,7 @@ import de.rayzs.pat.plugin.system.communication.pmc.PluginMessageClient;
 import de.rayzs.pat.api.storage.Storage;
 import net.md_5.bungee.api.event.PluginMessageEvent;
 import de.rayzs.pat.utils.CommunicationPackets;
+import de.rayzs.pat.plugin.logger.Logger;
 import net.md_5.bungee.api.connection.Server;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.plugin.Listener;
@@ -68,7 +69,7 @@ public class BungeePluginMessageClient implements PluginMessageClient, Listener 
             try {
                 serverInfo.sendData(CHANNEL_NAME, preparedPacket);
             } catch (Exception exception) {
-                exception.printStackTrace();
+                Logger.warning("Failed to send data to server: " + exception.getMessage());
             }
 
         }
@@ -98,7 +99,7 @@ public class BungeePluginMessageClient implements PluginMessageClient, Listener 
             Communicator.get().handleB2PPacket(serverName, (CommunicationPackets.PATPacket) packetObj);
 
         } catch (Throwable throwable) {
-            throwable.printStackTrace();
+            Logger.warning("Error handling plugin message: " + throwable.getMessage());
         }
 
     }

--- a/src/main/java/de/rayzs/pat/plugin/system/communication/pmc/impl/VelocityPluginMessageClient.java
+++ b/src/main/java/de/rayzs/pat/plugin/system/communication/pmc/impl/VelocityPluginMessageClient.java
@@ -2,6 +2,7 @@ package de.rayzs.pat.plugin.system.communication.pmc.impl;
 
 import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import com.velocitypowered.api.event.connection.PluginMessageEvent;
+import de.rayzs.pat.plugin.logger.Logger;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import de.rayzs.pat.plugin.system.communication.Communicator;
 import de.rayzs.pat.plugin.system.communication.pmc.PluginMessageClient;
@@ -68,7 +69,7 @@ public class VelocityPluginMessageClient implements PluginMessageClient {
             try {
                 registeredServer.sendPluginMessage(IDENTIFIER, preparedPacket);
             } catch (Exception exception) {
-                exception.printStackTrace();
+                Logger.warning("Failed to send plugin message: " + exception.getMessage());
             }
 
         }

--- a/src/main/java/de/rayzs/pat/plugin/system/serverbrand/impl/BukkitServerBrand.java
+++ b/src/main/java/de/rayzs/pat/plugin/system/serverbrand/impl/BukkitServerBrand.java
@@ -7,6 +7,7 @@ import de.rayzs.pat.api.storage.Storage;
 import de.rayzs.pat.plugin.BukkitLoader;
 import de.rayzs.pat.utils.scheduler.PATScheduler;
 import de.rayzs.pat.utils.scheduler.PATSchedulerTask;
+import de.rayzs.pat.plugin.logger.Logger;
 import io.netty.channel.Channel;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -56,7 +57,7 @@ public class BukkitServerBrand implements ServerBrand {
                 SERVER.getMessenger().registerOutgoingPluginChannel(BukkitLoader.getPlugin(), CHANNEL_NAME);
                 INITIALIZED = true;
             } catch (Exception exception) {
-                exception.printStackTrace();
+                Logger.warning("Failed to initialize server brand: " + exception.getMessage());
             }
         }
 
@@ -117,7 +118,7 @@ public class BukkitServerBrand implements ServerBrand {
             Reflection.closeAccess(channelsField);
 
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Failed to prepare player channels: " + exception.getMessage());
         }
 
     }
@@ -167,7 +168,7 @@ public class BukkitServerBrand implements ServerBrand {
             channel.pipeline().writeAndFlush(customPacketPayloadPacket);
 
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Failed to send custom brand: " + exception.getMessage());
         }
     }
 

--- a/src/main/java/de/rayzs/pat/plugin/system/serverbrand/impl/VelocityServerBrand.java
+++ b/src/main/java/de/rayzs/pat/plugin/system/serverbrand/impl/VelocityServerBrand.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import java.lang.reflect.Method;
 import io.netty.buffer.ByteBuf;
 import de.rayzs.pat.utils.*;
+import de.rayzs.pat.plugin.logger.Logger;
 import java.util.Optional;
 
 public class VelocityServerBrand implements ServerBrand {
@@ -98,7 +99,7 @@ public class VelocityServerBrand implements ServerBrand {
                     .get(0).invoke(minecraftConnectionObj, pluginMessagePacket);
 
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Failed to send brand: " + exception.getMessage());
         }
     }
 
@@ -124,7 +125,7 @@ public class VelocityServerBrand implements ServerBrand {
 
             return new PacketUtils.BrandManipulate(customBrand, false);
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Failed to create brand packet: " + exception.getMessage());
         }
 
         return null;

--- a/src/main/java/de/rayzs/pat/utils/PacketUtils.java
+++ b/src/main/java/de/rayzs/pat/utils/PacketUtils.java
@@ -1,6 +1,7 @@
 package de.rayzs.pat.utils;
 
 import java.nio.charset.StandardCharsets;
+import de.rayzs.pat.plugin.logger.Logger;
 import io.netty.buffer.*;
 
 public class PacketUtils {
@@ -73,7 +74,7 @@ public class PacketUtils {
             try {
                 writeString(brand, byteBuf);
             } catch (Exception exception) {
-                exception.printStackTrace();
+                Logger.warning("Failed to write brand string: " + exception.getMessage());
             }
 
             byte[] bytes = byteBuf.array();

--- a/src/main/java/de/rayzs/pat/utils/Reflection.java
+++ b/src/main/java/de/rayzs/pat/utils/Reflection.java
@@ -6,6 +6,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.logging.Logger;
 
 public class Reflection {
 
@@ -34,7 +35,7 @@ public class Reflection {
 
                 oldChannelMethod = software.isPaperBased() && weird;
             } catch (Exception exception) {
-                exception.printStackTrace();
+                Logger.getLogger(Reflection.class.getName()).severe("Error during initialization: " + exception.getMessage());
             }
 
             return;
@@ -89,7 +90,7 @@ public class Reflection {
         try {
             clazz = Class.forName(clazzPath);
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.getLogger(Reflection.class.getName()).severe("Failed to find class: " + exception.getMessage());
         }
         return clazz;
     }

--- a/src/main/java/de/rayzs/pat/utils/configuration/Configurator.java
+++ b/src/main/java/de/rayzs/pat/utils/configuration/Configurator.java
@@ -2,6 +2,7 @@ package de.rayzs.pat.utils.configuration;
 
 import de.rayzs.pat.utils.configuration.impl.*;
 import de.rayzs.pat.utils.*;
+import de.rayzs.pat.plugin.logger.Logger;
 import java.util.HashMap;
 import java.net.*;
 import java.io.*;
@@ -47,7 +48,7 @@ public class Configurator {
                 return connection.getInputStream();
             }
         } catch (Throwable throwable) {
-            throwable.printStackTrace();
+            Logger.warning("Failed to get resource: " + throwable.getMessage());
             return null;
         }
     }
@@ -81,7 +82,7 @@ public class Configurator {
                 inputStream.close();
             }
         } catch (Throwable throwable) {
-            throwable.printStackTrace();
+            Logger.warning("Failed to create resource file: " + throwable.getMessage());
         }
     }
 }

--- a/src/main/java/de/rayzs/pat/utils/configuration/impl/ProxyConfigurationBuilder.java
+++ b/src/main/java/de/rayzs/pat/utils/configuration/impl/ProxyConfigurationBuilder.java
@@ -35,7 +35,7 @@ public class ProxyConfigurationBuilder implements ConfigurationBuilder {
             loadDefault = !file.exists();
             if(!file.exists()) file.createNewFile();
             configuration = ConfigurationProvider.getProvider(YamlConfiguration.class).load(file);
-        } catch (Exception exception) { exception.printStackTrace(); }
+        } catch (Exception exception) { Logger.warning("Failed to initialize configuration: " + exception.getMessage()); }
     }
 
     @Override

--- a/src/main/java/de/rayzs/pat/utils/configuration/updater/ConfigUpdater.java
+++ b/src/main/java/de/rayzs/pat/utils/configuration/updater/ConfigUpdater.java
@@ -97,7 +97,7 @@ public class ConfigUpdater {
             Files.write(outdatedConfig.toPath(), input);
 
         } catch (Exception exception) {
-            exception.printStackTrace();
+            Logger.warning("Failed to read/write comparable config: " + exception.getMessage());
         }
 
         Logger.warning(" ");

--- a/src/main/java/de/rayzs/pat/utils/permission/PermissionUtil.java
+++ b/src/main/java/de/rayzs/pat/utils/permission/PermissionUtil.java
@@ -8,6 +8,7 @@ import de.rayzs.pat.utils.hooks.GroupManagerHook;
 import de.rayzs.pat.utils.group.GroupManager;
 import de.rayzs.pat.utils.sender.CommandSender;
 import de.rayzs.pat.utils.hooks.LuckPermsHook;
+import de.rayzs.pat.plugin.logger.Logger;
 
 public class PermissionUtil {
 
@@ -117,7 +118,7 @@ public class PermissionUtil {
                 try {
                     throw new Exception("Unknown sender!");
                 } catch (Exception exception) {
-                    exception.printStackTrace();
+                    Logger.warning("Failed to check permission: " + exception.getMessage());
                 }
 
                 return true;


### PR DESCRIPTION
Replaced printStackTrace() with proper logger calls across 17 files covering packet analyzers, server brand modules, plugin message clients, and utility classes. Each replacement uses the file's existing logger pattern (plugin.getLogger(), static Logger, or Bukkit.getLogger()). No behavioral changes — purely logging hygiene and minor code quality.