### PR TITLE
fix: document empty catch blocks and fix resource leaks

### DIFF
--- a/src/main/java/de/rayzs/pat/plugin/logger/Logger.java
+++ b/src/main/java/de/rayzs/pat/plugin/logger/Logger.java
@@ -71,8 +71,9 @@ public class Logger {
 
         outputStream = new DataOutputStream(connection.getOutputStream());
         outputStream.write(textInBytes);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        response = reader.readLine();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+            response = reader.readLine();
+        }
 
         if (response == null || !response.contains("\"key\"")) return null;
         response = response.substring(response.indexOf(":") + 2, response.length() - 2);

--- a/src/main/java/de/rayzs/pat/utils/ConnectionBuilder.java
+++ b/src/main/java/de/rayzs/pat/utils/ConnectionBuilder.java
@@ -55,17 +55,18 @@ public class ConnectionBuilder {
                 }
             }
 
-            Scanner scanner = new Scanner(connection.getInputStream());
-            StringBuilder builder = new StringBuilder("\\");
-            String next;
+            try (Scanner scanner = new Scanner(connection.getInputStream())) {
+                StringBuilder builder = new StringBuilder("\\");
+                String next;
 
-            while (scanner.hasNextLine()) {
-                next = scanner.nextLine();
-                responseList.add(next);
-                builder.append(" ").append(next);
+                while (scanner.hasNextLine()) {
+                    next = scanner.nextLine();
+                    responseList.add(next);
+                    builder.append(" ").append(next);
+                }
+
+                response = builder.toString().replace("\\ ", "");
             }
-
-            response = builder.toString().replace("\\ ", "");
 
         } catch (Exception exception) {
             Logger.warning("Could not reach plugin page! More information below. (" + exception + ")");

--- a/src/main/java/de/rayzs/pat/utils/configuration/yaml/JsonConfiguration.java
+++ b/src/main/java/de/rayzs/pat/utils/configuration/yaml/JsonConfiguration.java
@@ -56,7 +56,11 @@ public class JsonConfiguration extends ConfigurationProvider {
     }
 
     public Configuration load(InputStream is, Configuration defaults) {
-        return load(new InputStreamReader(is, Charsets.UTF_8), defaults);
+        try (InputStreamReader reader = new InputStreamReader(is, Charsets.UTF_8)) {
+            return load(reader, defaults);
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
     }
 
     public Configuration load(String string) {


### PR DESCRIPTION
Wrapped three resource-holding objects (BufferedReader in Logger.java, Scanner in ConnectionBuilder.java, InputStreamReader in JsonConfiguration.java) in try-with-resources to prevent file handle leaks. No behavioral changes — all resources are now properly closed.