### PR TITLE
fix: use Objects.requireNonNull instead of assert for null checks

### DIFF
--- a/src/main/java/de/rayzs/pat/plugin/BukkitLoader.java
+++ b/src/main/java/de/rayzs/pat/plugin/BukkitLoader.java
@@ -218,7 +218,7 @@ public class BukkitLoader extends JavaPlugin implements PluginLoader {
         final Player player = Bukkit.getPlayer(sender.getUniqueId());
 
         if (bukkitAntiTabListener != null) {
-            assert player != null;
+            Objects.requireNonNull(player);
             bukkitAntiTabListener.updateCommands(player);
         }
     }

--- a/src/main/java/de/rayzs/pat/plugin/command/commands/local/system/UpdateCommand.java
+++ b/src/main/java/de/rayzs/pat/plugin/command/commands/local/system/UpdateCommand.java
@@ -25,7 +25,7 @@ public class UpdateCommand extends ProCommand {
                 if (playerObj != null) {
                     CommandSender s = CommandSender.from(playerObj);
 
-                    assert s != null;
+                    Objects.requireNonNull(s);
                     PermissionUtil.reloadPermissions(s);
                 }
             });

--- a/src/main/java/de/rayzs/pat/plugin/listeners/bukkit/BukkitPlayerListener.java
+++ b/src/main/java/de/rayzs/pat/plugin/listeners/bukkit/BukkitPlayerListener.java
@@ -17,6 +17,8 @@ import org.bukkit.event.player.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.*;
 
+import java.util.Objects;
+
 public class BukkitPlayerListener implements Listener {
 
     @EventHandler
@@ -108,7 +110,7 @@ public class BukkitPlayerListener implements Listener {
         if (Storage.ConfigSections.Settings.UPDATE_GROUPS_PER_WORLD.ENABLED) {
             CommandSender sender = CommandSender.from(player);
 
-            assert sender != null;
+            Objects.requireNonNull(sender);
             PermissionUtil.reloadPermissions(sender);
             Storage.getLoader().updateCommands(sender);
         }

--- a/src/main/java/de/rayzs/pat/plugin/listeners/bungee/BungeePlayerConnectionListener.java
+++ b/src/main/java/de/rayzs/pat/plugin/listeners/bungee/BungeePlayerConnectionListener.java
@@ -9,6 +9,8 @@ import de.rayzs.pat.utils.permission.PermissionUtil;
 import de.rayzs.pat.utils.message.MessageTranslator;
 import de.rayzs.pat.utils.sender.CommandSender;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
+
+import java.util.Objects;
 import net.md_5.bungee.api.plugin.Listener;
 import de.rayzs.pat.api.storage.Storage;
 import de.rayzs.pat.plugin.BungeeLoader;
@@ -52,7 +54,7 @@ public class BungeePlayerConnectionListener implements Listener {
         if (Storage.ConfigSections.Settings.UPDATE_GROUPS_PER_SERVER.ENABLED) {
             CommandSender sender = CommandSender.from(player);
 
-            assert sender != null;
+            Objects.requireNonNull(sender);
             PermissionUtil.reloadPermissions(sender);
         }
 

--- a/src/main/java/de/rayzs/pat/plugin/listeners/velocity/VelocityConnectionListener.java
+++ b/src/main/java/de/rayzs/pat/plugin/listeners/velocity/VelocityConnectionListener.java
@@ -18,6 +18,8 @@ import com.velocitypowered.api.proxy.*;
 import de.rayzs.pat.utils.sender.CommandSender;
 import net.kyori.adventure.text.Component;
 
+import java.util.Objects;
+
 import java.util.concurrent.TimeUnit;
 
 public class VelocityConnectionListener {
@@ -92,7 +94,7 @@ public class VelocityConnectionListener {
             if (serverInfo != null) Storage.tempCachePlayerToServer(player.getUniqueId(), serverInfo.getName());
 
             CommandSender sender = CommandSender.from(player);
-            assert sender != null;
+            Objects.requireNonNull(sender);
             PermissionUtil.reloadPermissions(sender);
         }
 


### PR DESCRIPTION
Replaced 5 `assert` null checks with `Objects.requireNonNull()` across BukkitLoader, UpdateCommand, BukkitPlayerListener, BungeePlayerConnectionListener, and VelocityConnectionListener.

`assert` is disabled at runtime by default — it provides no null-safety in production. `Objects.requireNonNull()` always runs and fails fast when a null is passed, making debugging production issues much easier.

The changed null checks were for: player in BukkitLoader/UpdateCommand, sender in BukkitPlayerListener/BungeePlayerConnectionListener/VelocityConnectionListener.